### PR TITLE
Add require "rspec/core".

### DIFF
--- a/lib/rspec/endpoint.rb
+++ b/lib/rspec/endpoint.rb
@@ -1,4 +1,5 @@
 require "rspec/endpoint/version"
+require "rspec/core"
 
 module RSpec
   module Endpoint


### PR DESCRIPTION
Fix crash when test environment is loaded.

```
bin/rake db:migrate RAILS_ENV=test
rake aborted!
NoMethodError: undefined method `configure' for RSpec:Module
/home/alexandre/Workspace/dooctor/dooctor-admin/.gems/gems/rspec-endpoint-0.1.0/lib/rspec/endpoint.rb:31:in `<top (required)>'
/home/alexandre/Workspace/dooctor/dooctor-admin/.gems/gems/bundler-1.11.2/lib/bundler/runtime.rb:91:in `require'
/home/alexandre/Workspace/dooctor/dooctor-admin/.gems/gems/bundler-1.11.2/lib/bundler/runtime.rb:91:in `rescue in block in require'
/home/alexandre/Workspace/dooctor/dooctor-admin/.gems/gems/bundler-1.11.2/lib/bundler/runtime.rb:68:in `block in require'
/home/alexandre/Workspace/dooctor/dooctor-admin/.gems/gems/bundler-1.11.2/lib/bundler/runtime.rb:61:in `each'
/home/alexandre/Workspace/dooctor/dooctor-admin/.gems/gems/bundler-1.11.2/lib/bundler/runtime.rb:61:in `require'
/home/alexandre/Workspace/dooctor/dooctor-admin/.gems/gems/bundler-1.11.2/lib/bundler.rb:99:in `require'
/home/alexandre/Workspace/dooctor/dooctor-admin/config/application.rb:8:in `<top (required)>'
/home/alexandre/Workspace/dooctor/dooctor-admin/Rakefile:4:in `require'
/home/alexandre/Workspace/dooctor/dooctor-admin/Rakefile:4:in `<top (required)>'
```
