### PR TITLE
Fix making requests without path

### DIFF
--- a/lib/rspec/endpoint.rb
+++ b/lib/rspec/endpoint.rb
@@ -20,7 +20,7 @@ module RSpec
 
         path_params.each { |param| let(param.to_sym) { send(param.to_sym) } }
 
-        subject { send(method.to_sym, params) }
+        subject { send(method.to_sym, send(:path), params) }
 
         class_eval(&block)
       end

--- a/spec/rspec/endpoint_spec.rb
+++ b/spec/rspec/endpoint_spec.rb
@@ -6,6 +6,14 @@ RSpec.describe RSpec::Endpoint do
       let(:user_id) { 10 }
       let(:comment_id) { 20 }
 
+      before { allow(self).to receive(:post) }
+
+      it "makes a request" do
+        subject
+
+        expect(self).to have_received(:post).with(path, user_id: user_id, comment_id: comment_id)
+      end
+
       describe "#params" do
         subject { params }
         it { is_expected.to include user_id: 10 }


### PR DESCRIPTION
The subject that created was not making the request with the endpoint `path`.
