### PR TITLE
Add named subject `make_request`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,23 @@ RSpec.descripe UserApi do
   end
 end
 ```
+
+`rspec-endpoint` will define a named subject `make_request` which calls the provided path using the http verb.
+
+```ruby
+RSpec.descripe UserApi do
+  endpoint "POST /users/:user_id" do
+    let(:user_id) { 10 }
+
+    it do
+      # Named subject, same as:
+      #   post path, params
+      #
+      # `params` here is `{ user_id: user_id }`
+      make_request
+
+      expect(response).to be_success
+    end
+  end
+end
+```

--- a/lib/rspec/endpoint.rb
+++ b/lib/rspec/endpoint.rb
@@ -20,7 +20,7 @@ module RSpec
 
         path_params.each { |param| let(param.to_sym) { send(param.to_sym) } }
 
-        subject { send(method.to_sym, send(:path), params) }
+        subject(:make_request) { send(method.to_sym, send(:path), params) }
 
         class_eval(&block)
       end

--- a/spec/rspec/endpoint_spec.rb
+++ b/spec/rspec/endpoint_spec.rb
@@ -8,6 +8,10 @@ RSpec.describe RSpec::Endpoint do
 
       before { allow(self).to receive(:post) }
 
+      it "has a named subject" do
+        expect { make_request }.to_not raise_error
+      end
+
       it "makes a request" do
         subject
 


### PR DESCRIPTION
It is very common while testing endpoints to reuse the subject which makes the request and define a another subject to focus on response body, etc.

Now the subject is a named one, `make_request`, and allows the user to reuse it.
